### PR TITLE
Add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+
+FROM ubuntu:20.04
+
+# deal with timezones (change to what suits your use case)
+ENV TZ=America/New_York
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+WORKDIR home
+
+# need all of this to work (was missing some packages)
+RUN apt-get update \
+&&  apt-get -y install software-properties-common \
+&&  add-apt-repository ppa:deadsnakes/ppa \
+&&  apt-get install -y python3-scipy libopencv-dev python3-opencv \
+                     swig python3-systemd git astrometry.net \
+                     python3-astropy python3-pkgconfig \
+                     python3-dev libpython3.7-dev libpython3.8-dev \
+                     build-essential python3.6 libpython3.6-dev \
+                     python3-pandas \
+                     graphviz \
+                     bc \
+                     netcat \
+                     tzdata \
+&& rm -rf /var/lib/apt/lists/* 
+
+ADD http://data.astrometry.net/4100/index-4112.fits /usr/share/astrometry/
+ADD http://data.astrometry.net/4100/index-4113.fits /usr/share/astrometry/
+ADD http://data.astrometry.net/4100/index-4114.fits /usr/share/astrometry/
+ADD http://data.astrometry.net/4100/index-4115.fits /usr/share/astrometry/
+ADD http://data.astrometry.net/4100/index-4116.fits /usr/share/astrometry/
+ADD http://data.astrometry.net/4100/index-4117.fits /usr/share/astrometry/
+ADD http://data.astrometry.net/4100/index-4118.fits /usr/share/astrometry/
+ADD http://data.astrometry.net/4100/index-4119.fits /usr/share/astrometry/

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ According to their website,
 
 In practice, it's a nice way to ensure you always have the same dependencies installed, independent of the rest of your system.
 
+**Note:** the Docker environment here is best used for development purposed. When running openstartracker on a flight computer, it is most
+likely better to run the program directly, without the Docker container. Docker is used here just to create a standard, reproducible dev and testing environment.
+
 To use the Docker environment to run openstartracker,
 
 0. Install [Docker](https://docs.docker.com/get-docker/).

--- a/README.md
+++ b/README.md
@@ -41,19 +41,67 @@ cd openstartracker/tests
 ./unit_test.sh -crei science_cam_may8_0.05sec_gain40
 
 ~~~~
-##### To calibrate a new camera:
+
+#### Using Docker
+The included Dockerfile allows the build and test environment to be configured in a reproducible way with all the dependencies.
+According to their website,
+> Docker is an open platform for developing, shipping, and running applications. Docker enables you to separate your applications from your infrastructure so you can deliver software quickly.
+
+In practice, it's a nice way to ensure you always have the same dependencies installed, independent of the rest of your system.
+
+To use the Docker environment to run openstartracker,
+
+0. Install [Docker](https://docs.docker.com/get-docker/).
+1. Run `source setup.sh`. This will execute a `docker build ...` command to create the Docker environment from the Dockerfile, copy
+in all the code config files from this repo, 
+and create a command alias called `dstart` that can be run to start the Docker environment and access the pre-built Docker environment.
+  - This may take awhile to run the first time as the Docker image is built, but will run much more quickly in subsequent builds
+2. Run `dstart` to start and enter the Docker environment.
+3. Proceed with the following instructions.
+
+**Important note:** Any code and file changes should be made **outside** the Docker environment -- consider it a 'run only' space.
+Any time you make a change to the code in this repo, you'll want to re-run the `source setup.sh` command so that your changes are
+included in the Docker build.
+
+### Run on example imagery:
+You can use the included `science_cam_may8_0.05sec_gain40` images to test out the calibration process:
+
+```
+# if using docker, run `source setup.sh` and then `dstart` to enter the Docker shell
+cd tests/
+./unit_test.sh -crei science_cam_may8_0.05sec_gain40/
+```
+
+This command will **c**alibrate your image sensor, **r** regenerate the test data, run an **E**SA test, and finally run the **i**mage test where images are fed to the calibrated star tracker program to produce an attitude fix.
+
+The usage message for `unit_test.py` is here:
+```
+./unit_test.sh -h
+Usage: ./unit_test.sh [options] testdir [cmd]
+
+	-c	Calibrate based on images in testdir/samples/
+	-r	Regenerate ESA test
+	-e	Run ESA test
+	-i	Run image test
+```
+
+### To calibrate a new camera:
+1. Create directories for you camera's imagery:
 ~~~~
-cd openstartracker/
+cd openstartracker/tests/
 mkdir yourcamera
 mkdir yourcamera/samples
 mkdir yourcamera/calibration_data
 ~~~~
-add 3-10 star images of different parts of the sky taken with your camera to yourcamera/samples
-
-edit APERTURE and EXPOSURE_TIME in calibrate.py (you want to take images with the lowest exposure time that consistently solves)
-
-
-run ./unit_test.sh -crei yourcamera to recalibrate and test
+2. Add 3-10 star images of different parts of the sky taken with your camera to `tests/yourcamera/samples`
+3. Edit `APERTURE` and `EXPOSURE_TIME` in `calibrate.py` (you want to take images with the lowest exposure time that consistently solves)
+4. (if using docker, run `dstart` to enter the Docker environment)
+5. Run 
+  ```
+  cd tests/
+  ./unit_test.sh -crei yourcamera
+  ```
+  to calibrate and test
 
 The ESA test should have a score of >70. If its worse than this, play around with exposure time (50ms is a good starting point)
 

--- a/beast/Makefile
+++ b/beast/Makefile
@@ -1,5 +1,5 @@
 CC = g++
-PYTHONHEADERS=/usr/include/python3.5
+PYTHONHEADERS=/usr/include/python3.8
 #PYTHONHEADERS=/usr/include/python2.7
 
 all: $(OBJ)

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# requires docker to be installed
+
+# build the Dockerfile to include the current director and have internet access
+docker build --network=host -t startracker1 .
+
+# directory of this setup.sh script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# Make an alias to start the docker environment
+#   in interactive mode
+#   in the proper directory
+alias dstart='docker run -it -v '$DIR'/:/home startracker1'

--- a/tests/unit_test.sh
+++ b/tests/unit_test.sh
@@ -83,18 +83,18 @@ if [[ $IMG_TEST == 1 ]]; then
 	KILLPID="$!"
 	sleep 10
 	#make sure we dont crash when given an image w/ no stars
-	echo "rgb.solve_image('$TESTDIR/median_image.png')" | nc 127.0.0.1 8010
+	echo "rgb.solve_image('$TESTDIR/median_image.png')" | nc -w1 127.0.0.1 8010
 	sleep 0.5
 	for i in $TESTDIR/samples/*; do
-		echo "rgb.solve_image('$i')" | nc 127.0.0.1 8010
+		echo "rgb.solve_image('$i')" | nc -w1 127.0.0.1 8010
 		sleep 0.5
-		echo "rgb.solve_image('$i')" | nc 127.0.0.1 8010
+		echo "rgb.solve_image('$i')" | nc -w1 127.0.0.1 8010
 		sleep 0.5
 	done
   #sleep 0.5
   #echo 'exception test' | nc 127.0.0.1 8010
   sleep 0.5
-	echo 'quit()' | nc 127.0.0.1 8010
+	echo 'quit()' | nc -w1 127.0.0.1 8010
 fi
 if [ "$KILLPID" != "" ] ; then 
 	kill $KILLPID

--- a/tests/unit_test.sh
+++ b/tests/unit_test.sh
@@ -5,8 +5,8 @@ REGENERATE=0
 ESA_TEST=0
 IMG_TEST=0
 
-PYTHON="/usr/bin/python2.7"
-#PYTHON="/usr/bin/python3.5"
+#PYTHON="/usr/bin/python2.7"
+PYTHON="/usr/bin/python3.8"
 
 while getopts ":crei" opt; do
   case $opt in


### PR DESCRIPTION
This PR adds a (totally optional) Docker build capability for openstartracker development and testing. It's based on the Dockerfile from the [Stanford-SSI openstartracker fork](https://github.com/stanford-ssi/openstartracker), which hasn't seen much development lately. 

I really like using the Docker setup for testing - it makes it really easy to make sure I always have the right libraries and requirements (and the right versions of all those dependencies). I think it will also make the project easier to quickstart for new users - rather than needing to install all the dependencies on a fresh Ubuntu image, the Docker process pulls in a fresh Ubuntu environment, adds the deps, and presents a clean sandbox for testing, regardless of the state of the user's computer. This can also be run from any platform, not just Linux.

Openstartracker can still be run in exactly the same way it's normally run - the Docker stuff is totally optional. In fact, in production/flight, Docker probably shouldn't be used at all because of the slight overhead it incurs. I've updated the README instructions to reflect this.

I also made a few small changes to the python versions and the nc commands to work with the particular version of python and netcat that the Docker image pulls in.

Happy to field any questions here!